### PR TITLE
Updated Android fotoapparat to 2.8.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation 'cz.adaptech:tesseract4android:4.9.0'
 
     implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'io.fotoapparat:fotoapparat:2.7.0'
+    implementation 'io.fotoapparat:fotoapparat:2.8.0'
 }
 
 configurations.all {


### PR DESCRIPTION
Fixes 'io.fotoapparat:fotoapparat:2.7.0' not found exception